### PR TITLE
fix: interest rate is always set to coupon on update

### DIFF
--- a/models/contract.js
+++ b/models/contract.js
@@ -511,6 +511,14 @@ module.exports = (sequelize, DataTypes) => {
     );
   };
 
+  contract.prototype.getInterestRateTypeValue = function () {
+    const rateType =
+      this.interest_rate_type ||
+      settings.project.get("defaults.interest_rate_type") ||
+      "money";
+    return rateType;
+  };
+  
   contract.prototype.getInterestRateType = function () {
     const rateType =
       this.interest_rate_type ||

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "habidat-direktkredit",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "private": false,
   "scripts": {
     "start": "node ./bin/www"

--- a/views/contract/form.pug
+++ b/views/contract/form.pug
@@ -18,7 +18,7 @@ mixin contract_form(action, updateAction, updateTag, editContract, updateForm = 
     - var termination_period = editContract?editContract.getTerminationPeriod():settings.project.get('defaults.termination_period');
     - var termination_period_type = editContract?editContract.getTerminationPeriodType():settings.project.get('defaults.termination_period_type');
     - var interest_payment_type = editContract?editContract.getInterestPaymentType():settings.project.get('defaults.interest_payment_type');
-    - var interest_rate_type = editContract?editContract.getInterestRateType():settings.project.get('defaults.interest_rate_type');
+    - var interest_rate_type = editContract?editContract.getInterestRateTypeValue():settings.project.get('defaults.interest_rate_type');
     +is_import('contract_sign_date', 'sign_date'): +date('sign_date')(value=_iv(editContract, 'sign_date') required)
     +is_import('contract_amount', 'amount'): +money('amount')(value=_iv(editContract, 'amount') required)
     +is_import('contract_interest_rate', 'interest_rate'): +percent('interest_rate')(min="0" max="10" value=_iv(editContract, 'interest_rate') required)


### PR DESCRIPTION
The credit edit form cannot match interest rate type because it's already translated. This change uses the raw value